### PR TITLE
chore: update GitHub Actions workflow to include permissions for content access

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   publish-npm:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       npm-published: ${{ steps.npm-publish.outputs.published }}
       npm-version: ${{ steps.get-version.outputs.version }}
@@ -157,6 +159,8 @@ jobs:
 
   summary:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     needs: [publish-npm, publish-github-packages]
     if: always()
     steps:


### PR DESCRIPTION

- Added 'permissions' section with 'contents: read' to the 'publish-npm' and 'summary' jobs in the publish-package.yml file.

This change ensures that the workflow has the necessary permissions to read repository contents during the publishing process.