### PR TITLE
Potential fix for code scanning alert no. 20: Use of a broken or weak cryptographic hashing algorithm on sensitive data

### DIFF
--- a/internal/crypto/crypto.go
+++ b/internal/crypto/crypto.go
@@ -81,10 +81,13 @@ func Decrypt(ciphertext []byte, key []byte) ([]byte, error) {
 	return plaintext, nil
 }
 
-// HashPassword creates a SHA-256 hash of the password for verification
-func HashPassword(password string) string {
-	hash := sha256.Sum256([]byte(password))
-	return base64.StdEncoding.EncodeToString(hash[:])
+// HashPassword creates a computationally expensive hash of the password for verification
+func HashPassword(password string, salt []byte) (string, error) {
+	hash, err := scrypt.Key([]byte(password), salt, scryptN, scryptR, scryptP, keySize)
+	if err != nil {
+		return "", fmt.Errorf("failed to hash password: %w", err)
+	}
+	return base64.StdEncoding.EncodeToString(hash), nil
 }
 
 // HashData creates a SHA-256 hash of arbitrary data


### PR DESCRIPTION
Potential fix for [https://github.com/hungnguyen18/uzp-cli/security/code-scanning/20](https://github.com/hungnguyen18/uzp-cli/security/code-scanning/20)

In general, to fix this issue you must replace the direct SHA-256 hash of the password with a password hashing / key-derivation function that is intentionally computationally expensive and uses a salt. Since this file already imports and uses `golang.org/x/crypto/scrypt` with fixed parameters and `keySize`, the best fix with minimal behavioral change is to use `scrypt.Key` to derive a fixed-length hash from the password and a caller-supplied salt, then encode that derived key in base64 for storage/verification.

Concretely, in `internal/crypto/crypto.go`:

- Change `HashPassword` to no longer use `sha256.Sum256`. Instead, make it accept a salt (so different users can have different salts), call `scrypt.Key([]byte(password), salt, scryptN, scryptR, scryptP, keySize)`, and base64-encode the resulting derived key.
- This aligns password hashing with the existing `DeriveKey` parameters (N, r, p, keySize), without adding any new dependencies or concepts.
- The function signature needs to change from `func HashPassword(password string) string` to `func HashPassword(password string, salt []byte) (string, error)` so it can propagate scrypt errors. Callers that currently used a no-arg salt will now be able to use `GenerateSalt()` from the same file.

We should not change `HashData`, as SHA-256 is appropriate for general data hashing.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes password hashing behavior and `HashPassword` API, which can break callers and requires correct salt generation/storage for verification. Security impact is positive but incorrect integration could lock users out or weaken verification.
> 
> **Overview**
> Updates `HashPassword` in `internal/crypto/crypto.go` to stop using a direct SHA-256 hash and instead derive a base64-encoded password hash via `scrypt.Key` with caller-supplied salt and error propagation.
> 
> `HashData` remains SHA-256 for non-password data, limiting the change to password verification semantics.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 92357e3a44de313bb3b389809ca09fc217d1d3d9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->